### PR TITLE
Fix security hole ... do *NOT* open the app port on the outside if the port is only meant for internal reverse-proxy use !

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -61,18 +61,11 @@ ynh_app_setting_set --app=$app --key=hashed_password --value=$hashed_password
 #=================================================
 # FIND AND OPEN A PORT
 #=================================================
-ynh_script_progression --message="Configuring firewall..."
+ynh_script_progression --message="Finding an available port..."
 
 # Find an available port
 port=$(ynh_find_port --port=8095)
 ynh_app_setting_set --app=$app --key=port --value=$port
-
-# Optional: Expose this port publicly
-# (N.B. : you only need to do this if the app actually needs to expose the port publicly.
-# If you do this and the app doesn't actually need you are CREATING SECURITY HOLES IN THE SERVER !)
-
-# Open the port
-ynh_exec_warn_less yunohost firewall allow --no-upnp TCP $port
 
 #=================================================
 # INSTALL DEPENDENCIES

--- a/scripts/remove
+++ b/scripts/remove
@@ -84,16 +84,6 @@ ynh_script_progression --message="Removing logrotate configuration..."
 ynh_remove_logrotate
 
 #=================================================
-# CLOSE A PORT
-#=================================================
-
-if yunohost firewall list | grep -q "\- $port$"
-then
-	ynh_script_progression --message="Closing port $port..."
-	ynh_exec_warn_less yunohost firewall disallow TCP $port
-fi
-
-#=================================================
 # SPECIFIC REMOVE
 #=================================================
 # REMOVE LOG FILES

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -90,6 +90,13 @@ if [ -z "$hashed_password" ]; then
 	ynh_app_setting_set --app=$app --key=hashed_password --value=$hashed_password
 fi
 
+# In previous versions, the port was mistakenly exposed to the outside world >_>
+if yunohost firewall list | grep -q "\- $port$"
+then
+	ynh_script_progression --message="Closing port $port..."
+	ynh_exec_warn_less yunohost firewall disallow TCP $port
+fi
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================


### PR DESCRIPTION
NB : I haven't checked to be 100% sure it's not needed, feel free to close and ignore if this PR is not relevant. I'm just trying to through all the possible apps with this issue ...

Otherwise : 
- this should be fixed ASAP >_>
- I haven't checked other scripts (upgrade, restore, ..?) which may also have this line in where this should be removed
- To properly fix the issue for existing installs, the remove script should be adapted to close that port if it's opened...
