### PR TITLE
manifest.toml make default permission visitors access

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -36,6 +36,7 @@ ram.runtime = "50M"
 
     [install.init_main_permission]
     type = "group"
+    default = "visitors"
 
     [install.theme]
     ask.en = "Choose a theme"


### PR DESCRIPTION

If you're sharing a link with someone, the goal is to make it short and simple. If someone installs this with default settings previously, they would have to log in with SSO to access that shortened link. As LSTU already has its own login interface, I believe that there is no harm and only benefit in making this by default accessible by visitors, which removes the yunohost SSO login requirement.
### Default currently:
![image](https://github.com/YunoHost-Apps/lstu_ynh/assets/54383546/4f914bf9-0fab-4881-85b5-1459a1b5da0e)

### All I'm Changing:
![image](https://github.com/YunoHost-Apps/lstu_ynh/assets/54383546/710bc9ed-b8ad-49a6-99e9-ba32b575be8d)

## Problem

By default, shortened URLs are not publicly accessible

## Solution

Change the default permission

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
